### PR TITLE
feat:update group.ts schema and functions in group.ts, membership.ts

### DIFF
--- a/app/lib/db/schema/group.ts
+++ b/app/lib/db/schema/group.ts
@@ -33,7 +33,12 @@ export const groupMember = pgTable(
 		userId: text('user_id')
 			.notNull()
 			.references(() => user.id),
-
+        userName: text('user_name')
+            .notNull()
+            .references(() => user.name),
+        role: text('role')
+            .notNull()
+            .default('Member'),
 		...timestampAttributes,
 	},
 	table => [table.groupId, table.userId],

--- a/app/lib/db/schema/group.ts
+++ b/app/lib/db/schema/group.ts
@@ -17,7 +17,7 @@ export const group = pgTable('group', {
 	status: text('status').notNull().default('active'),
 	proposedBudget: text('proposed_budget'),
 	foodPreference: text('food_preference'),
-	numofPeople: integer('num_of_people'),
+	numofPeople: integer('num_of_people').notNull(),
 	startTime: timestamp('start_time'),
 	spokenLanguage: text('spoken_language'),
 
@@ -30,6 +30,9 @@ export const groupMember = pgTable(
 		groupId: text('group_id')
 			.notNull()
 			.references(() => group.id, { onDelete: 'cascade' }),
+		groupName: text('group_name')
+			.notNull()
+			.references(() => group.name),
 		userId: text('user_id')
 			.notNull()
 			.references(() => user.id),

--- a/app/routes/web/api/membership.ts
+++ b/app/routes/web/api/membership.ts
@@ -10,10 +10,11 @@ import { redirect } from 'react-router'
 import { auth } from '~/lib/auth/auth.server'
 
 import type { Route } from './+types/membership'
-import { eq, and} from 'drizzle-orm'
+import { eq, and, sql} from 'drizzle-orm'
 import { db } from '~/lib/db/db.server'
 import * as schema from '~/lib/db/schema'
 import type { ConventionalActionResponse } from '~/lib/utils'
+
 
 // action 負責處理 POST、PUT、DELETE request
 export async function action({ request, params }: Route.ActionArgs) {
@@ -23,21 +24,76 @@ export async function action({ request, params }: Route.ActionArgs) {
 
 	const membershipId = params.id // 我有在 app/routes/web/routes.ts 設定 /:id
 	const user = session.user
+	const { groupId } = await request.json()
 	// 以下可以開始處理 user 與 membership id
 	// ...
 
 	switch (request.method) {
 		case 'POST':
-			const newMember = await db.insert(schema.groupMember).values({
-				groupId: schema.group.id,
-				userId: user.id,
-				userName: user.name,
-			})
-			return {
-				msg: '新成員已加入',
-				data: newMember,
-			} satisfies ConventionalActionResponse
+			{
+				// 1. Get group info (including member limit)
+				const group = await db.query.group.findFirst({
+				  where: eq(schema.group.id, groupId), 
+				  columns: {
+					id: true,
+					name: true,
+					numofPeople: true,
+					status: true,
+				  },
+				})
+		  
+					if (!group)
+						 {return{ msg: 'Group not found.',
+							 data: null,
+						} satisfies ConventionalActionResponse
+				}
+		  
+				// 2. Count current members in group
+				const userCount = await db 
+					.select({ count: sql<number>`COUNT(*)` }) 
+					.from(schema.groupMember)
+					.where(eq(schema.groupMember.groupId, groupId))
+				
+				const groupData = await db
+					.select({ numOfPeople: schema.group.numofPeople }) 
+					.from(schema.group)
+					.where(eq(schema.group.id, groupId))
+				  
+				  // 3. Check if user count >= group's member limit
+				  if (userCount[0].count >= groupData[0].numOfPeople!) {
+					await db.update(schema.group).set({ status: 'full' }).where(eq(schema.group.id, groupId))
+				
+					return {
+						msg: '群組已滿，無法新增成員。',
+						data: null,
+					} satisfies ConventionalActionResponse
+				}
+				
+				// 4. Insert new member
+				const newMember = await db.insert(schema.groupMember).values({
+					groupId: groupId,
+					groupName: group.name,
+					userId: user.id,
+					userName: user.name
+				  })
 
+					if (userCount[0].count + 1 === groupData[0].numOfPeople) {
+					await db
+					  .update(schema.group)
+					  .set({ status: 'full' })
+					  .where(eq(schema.group.id, groupId))
+				  }
+
+						return {
+				  		msg: '新成員已加入',
+				  		data: await db.insert(schema.groupMember).values({
+								groupId: groupId,
+								groupName: group.name,
+								userId: user.id,
+								userName: user.name
+							}),
+						} satisfies ConventionalActionResponse
+					}
 		case 'PUT':
 			const updatedMember = await db
         		.update(schema.groupMember)
@@ -48,10 +104,10 @@ export async function action({ request, params }: Route.ActionArgs) {
                 		eq(schema.groupMember.groupId, schema.group.id)
             	)
         	);
-    return {
-        msg: '成員已升級為管理員',
-        data: updatedMember,
-    } satisfies ConventionalActionResponse
+    		return {
+        	msg: '成員已升級為管理員',
+       		data: updatedMember,
+    		} satisfies ConventionalActionResponse
 
 		case 'DELETE':
             const leaveGroup = await db
@@ -72,7 +128,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 				status: 405,
 				statusText: 'Method Not Allowed',
 			})
-	}
+	}}
 
 // Loader 負責處理 GET request
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -82,22 +138,29 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 	const membershipId = params.id // 我有在 app/routes/web/routes.ts 設定 /:id
 	const user = session.user
-	 // 我有在 app/routes/web/routes.ts 設定 /:groupId
-	// 以下可以開始處理 user 與 membership id
-	// ...
+	const { groupId } = await request.json();
+	// 取得使用者加入的群組
+	const userGroups = await db.query.groupMember.findMany({
+		where: (groupMemberTable, { eq }) => eq(groupMemberTable.userId, user.id),
+		with: {
+	  	group: true,  // 連結群組表，拿群組資料
+		},
+  	});
 
-	const membership = await db.query.groupMember.findFirst({
-        where: (groupMemberTable, { eq }) => eq(groupMemberTable.id, membershipId),
-        with: {
-            group: true, // Include group details
-            user: true,  // Include user details
-        },
-    });
+	// 取得群組成員資料
+	const membersInGroup = await db.query.groupMember.findMany({
+		where: (groupMemberTable, { eq }) => eq(groupMemberTable.groupId, groupId),
+		with: {
+		  user: true,  // 一併帶出使用者資料
+		},
+	  });
+	  
 
 	// 返回資料
 	return {
 		api: '成員',
 		id: membershipId,
-		membership: membership
+		members: membersInGroup,
+		userGroups: userGroups,
 	}
 }

--- a/app/routes/web/api/membership.ts
+++ b/app/routes/web/api/membership.ts
@@ -10,6 +10,10 @@ import { redirect } from 'react-router'
 import { auth } from '~/lib/auth/auth.server'
 
 import type { Route } from './+types/membership'
+import { eq, and} from 'drizzle-orm'
+import { db } from '~/lib/db/db.server'
+import * as schema from '~/lib/db/schema'
+import type { ConventionalActionResponse } from '~/lib/utils'
 
 // action 負責處理 POST、PUT、DELETE request
 export async function action({ request, params }: Route.ActionArgs) {
@@ -24,27 +28,51 @@ export async function action({ request, params }: Route.ActionArgs) {
 
 	switch (request.method) {
 		case 'POST':
-			// 處理 POST 請求，通常是用來創建新的資源
-			break
+			const newMember = await db.insert(schema.groupMember).values({
+				groupId: schema.group.id,
+				userId: user.id,
+				userName: user.name,
+			})
+			return {
+				msg: '新成員已加入',
+				data: newMember,
+			} satisfies ConventionalActionResponse
+
 		case 'PUT':
-			// 處理 PUT 請求，通常是用來更新現有的資源
-			break
+			const updatedMember = await db
+        		.update(schema.groupMember)
+        		.set({ role: 'Admin' })
+        		.where(
+            		and(
+                		eq(schema.groupMember.userId, user.id),
+                		eq(schema.groupMember.groupId, schema.group.id)
+            	)
+        	);
+    return {
+        msg: '成員已升級為管理員',
+        data: updatedMember,
+    } satisfies ConventionalActionResponse
+
 		case 'DELETE':
-			// 處理 DELETE 請求，通常是用來刪除資源
-			break
+            const leaveGroup = await db
+                .delete(schema.groupMember)
+                .where(
+                    and(
+                        eq(schema.groupMember.userId, user.id),
+                        eq(schema.groupMember.groupId, schema.group.id)
+                    )
+                );
+
+            return {
+                msg: '成員已退出',
+                data: leaveGroup,
+            } satisfies ConventionalActionResponse
 		default:
 			throw new Response('', {
 				status: 405,
 				statusText: 'Method Not Allowed',
 			})
 	}
-
-	// 返回資料
-	return {
-		api: '群組',
-		id: membershipId,
-	}
-}
 
 // Loader 負責處理 GET request
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -54,12 +82,22 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 	const membershipId = params.id // 我有在 app/routes/web/routes.ts 設定 /:id
 	const user = session.user
+	 // 我有在 app/routes/web/routes.ts 設定 /:groupId
 	// 以下可以開始處理 user 與 membership id
 	// ...
 
+	const membership = await db.query.groupMember.findFirst({
+        where: (groupMemberTable, { eq }) => eq(groupMemberTable.id, membershipId),
+        with: {
+            group: true, // Include group details
+            user: true,  // Include user details
+        },
+    });
+
 	// 返回資料
 	return {
-		api: '群組',
+		api: '成員',
 		id: membershipId,
+		membership: membership
 	}
 }


### PR DESCRIPTION
1.group schema有稍微更動
2.建立群組時會同時把創群人加到成員列表（但創群組的細節我沒寫），成為管理員
3.在group loader新增GET activeGroups
4.membership.ts:成員只能加入activeGroups，且達到人數上限會將群組狀態更新為full
5.(上次的）管理員退出可以選擇刪除群組或指定管理員，沒有指定就是最早加入的成員變管理員
